### PR TITLE
Refactoring options

### DIFF
--- a/bridge/doctrine-orm/src/FieldMapper.php
+++ b/bridge/doctrine-orm/src/FieldMapper.php
@@ -7,6 +7,7 @@ namespace Psi\Bridge\ContentType\Doctrine\Orm;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Psi\Component\ContentType\Field;
 use Psi\Component\ContentType\FieldLoader;
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\Standard\Storage\CollectionType;
 use Psi\Component\ContentType\Standard\Storage\DateTimeType;
 use Psi\Component\ContentType\Standard\Storage\IntegerType;
@@ -111,7 +112,7 @@ class FieldMapper
     private function mapCollectionType($fieldName, Field $field, ClassMetadata $metadata)
     {
         $options = $field->getOptions();
-        $collectionField = $this->fieldLoader->load($options['field_type'], $options['field_options']);
+        $collectionField = $this->fieldLoader->load($options['field_type'], FieldOptions::create($options['field_options']));
 
         // assume that other types are scalars...
         $this->__invoke($fieldName, $collectionField, $metadata, [

--- a/bridge/doctrine-orm/tests/Functional/GeneralTest.php
+++ b/bridge/doctrine-orm/tests/Functional/GeneralTest.php
@@ -34,20 +34,20 @@ class GeneralTest extends OrmTestCase
                         ],
                         'referencedImage' => [
                             'type' => 'object_reference',
-                            'options' => [
+                            'shared' => [
                                 'class' => Image::class,
                             ],
                         ],
                         'paragraphs' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'text',
                                 'field_options' => [],
                             ],
                         ],
                         'numbers' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'integer',
                             ],
                         ],

--- a/bridge/doctrine-phpcr-odm/src/FieldMapper.php
+++ b/bridge/doctrine-phpcr-odm/src/FieldMapper.php
@@ -7,6 +7,7 @@ namespace Psi\Bridge\ContentType\Doctrine\PhpcrOdm;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Psi\Component\ContentType\Field;
 use Psi\Component\ContentType\FieldLoader;
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\Standard\Storage\CollectionType;
 use Psi\Component\ContentType\Standard\Storage\DateTimeType;
 use Psi\Component\ContentType\Standard\Storage\IntegerType;
@@ -111,7 +112,7 @@ class FieldMapper
     private function mapCollectionType($fieldName, Field $field, ClassMetadata $metadata)
     {
         $options = $field->getOptions();
-        $collectionField = $this->fieldLoader->load($options['field_type'], $options['field_options']);
+        $collectionField = $this->fieldLoader->load($options['field_type'], FieldOptions::create($options['field_options']));
 
         if ($collectionField->getStorageType() === ObjectType::class) {
             $options = $collectionField->getStorageOptions();

--- a/bridge/doctrine-phpcr-odm/tests/Functional/CollectionType/ObjectTest.php
+++ b/bridge/doctrine-phpcr-odm/tests/Functional/CollectionType/ObjectTest.php
@@ -20,13 +20,13 @@ class ObjectTest extends PhpcrOdmTestCase
                     'fields' => [
                         'slideshow' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'image',
                             ],
                         ],
                         'objectReferences' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'object_reference',
                             ],
                         ],

--- a/bridge/doctrine-phpcr-odm/tests/Functional/CollectionType/ObjectUnrestrictTest.php
+++ b/bridge/doctrine-phpcr-odm/tests/Functional/CollectionType/ObjectUnrestrictTest.php
@@ -70,7 +70,7 @@ class ObjectUnrestrictTest extends PhpcrOdmTestCase
                     ],
                     'slideshow' => [
                         'type' => 'collection',
-                        'options' => [
+                        'shared' => [
                             'field_type' => 'image',
                         ],
                     ],

--- a/bridge/doctrine-phpcr-odm/tests/Functional/GeneralTest.php
+++ b/bridge/doctrine-phpcr-odm/tests/Functional/GeneralTest.php
@@ -53,13 +53,13 @@ class GeneralTest extends PhpcrOdmTestCase
                     'fields' => [
                         'slideshow' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'image',
                             ],
                         ],
                         'objectReferences' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'object_reference',
                             ],
                         ],
@@ -80,14 +80,14 @@ class GeneralTest extends PhpcrOdmTestCase
                     'fields' => [
                         'paragraphs' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'text',
                                 'field_options' => [],
                             ],
                         ],
                         'numbers' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'integer',
                             ],
                         ],

--- a/schema/mapping.xsd
+++ b/schema/mapping.xsd
@@ -5,50 +5,59 @@
     xmlns:psi="http://github.com/psiphp/content-type/mapping"
     elementFormDefault="qualified">
 
-  <xs:annotation>
-      <xs:documentation><![CDATA[
-          This is the XML schema for the class mappings
-          for the Psi Content Type component.
-     ]]></xs:documentation>
-  </xs:annotation>
+    <xs:annotation>
+        <xs:documentation><![CDATA[
+            This is the XML schema for the class mappings
+            for the Psi Content Type component.
+            ]]></xs:documentation>
+    </xs:annotation>
 
-  <xs:element name="content-type-mapping">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element name="class" type="psi:class" minOccurs="1" maxOccurs="1" />
-      </xs:sequence>
+    <xs:element name="content-type-mapping">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="class" type="psi:class" minOccurs="1" maxOccurs="1" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="class">
+        <xs:sequence>
+            <xs:element name="field" type="psi:field" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
     </xs:complexType>
-  </xs:element>
 
-  <xs:complexType name="class">
-    <xs:sequence>
-      <xs:element name="field" type="psi:field" minOccurs="0" maxOccurs="unbounded"/>
-    </xs:sequence>
-    <xs:attribute name="name" type="xs:string" use="required" />
-</xs:complexType>
+    <xs:complexType name="field">
+        <xs:sequence>
+            <xs:element name="shared-options" type="psi:option-set" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="form-options" type="psi:option-set" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="view-options" type="psi:option-set" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="storage-options" type="psi:option-set" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="type" type="xs:string" use="required" />
+        <xs:attribute name="role" type="xs:string" />
+        <xs:attribute name="group" type="xs:string" />
+    </xs:complexType>
 
-  <xs:complexType name="field">
-    <xs:sequence>
-      <xs:element name="option" type="psi:option" minOccurs="0" maxOccurs="unbounded"/>
-    </xs:sequence>
-    <xs:attribute name="name" type="xs:string" use="required" />
-    <xs:attribute name="type" type="xs:string" use="required" />
-    <xs:attribute name="role" type="xs:string" />
-    <xs:attribute name="group" type="xs:string" />
-  </xs:complexType>
+    <xs:complexType name="option" mixed="true">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="option" type="psi:option"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="type" type="psi:option_type" />
+    </xs:complexType>
 
-  <xs:complexType name="option" mixed="true">
-    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="option" type="psi:option"/>
-    </xs:sequence>
-    <xs:attribute name="name" type="xs:string" use="required"/>
-    <xs:attribute name="type" type="psi:option_type" />
-  </xs:complexType>
+    <xs:complexType name="option-set">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="option" type="psi:option"/>
+        </xs:sequence>
+    </xs:complexType>
 
-  <xs:simpleType name="option_type">
-    <xs:restriction base="xs:token">
-      <xs:enumeration value="collection"/>
-      <xs:enumeration value="scalar"/>
-    </xs:restriction>
-  </xs:simpleType>
+    <xs:simpleType name="option_type">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="collection"/>
+            <xs:enumeration value="scalar"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/src/Field.php
+++ b/src/Field.php
@@ -10,18 +10,20 @@ class Field
 {
     private $resolved;
     private $resolver;
-    private $options;
     private $field;
+    private $options;
 
-    public function __construct(FieldInterface $field, array $options)
-    {
+    public function __construct(
+        FieldInterface $field,
+        FieldOptions $options
+    ) {
         $this->field = $field;
         $this->options = $options;
     }
 
     public function getOptions(): array
     {
-        return $this->resolve('resolve');
+        return $this->getResolver()->resolve($this->options->getSharedOptions());
     }
 
     public function getFormType(): string

--- a/src/FieldLoader.php
+++ b/src/FieldLoader.php
@@ -14,7 +14,7 @@ class FieldLoader
         $this->fieldRegistry = $fieldRegistry;
     }
 
-    public function load(string $type, array $options = []): Field
+    public function load(string $type, FieldOptions $options): Field
     {
         $hash = md5(serialize($options)) . $type;
 

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Psi\Component\ContentType;
+
+final class FieldOptions
+{
+    private $sharedOptions;
+    private $formOptions;
+    private $viewOptions;
+    private $storageOptions;
+
+    public static function create(array $options)
+    {
+        $defaults = [
+            'shared' => [],
+            'form' => [],
+            'view' => [],
+            'storage' => [],
+        ];
+
+        if ($diff = array_diff(array_keys($options), array_keys($defaults))) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unexpected field option keys: "%s". Allowed keys: "%s"',
+                implode('", "', $diff), implode('", "', array_keys($defaults))
+            ));
+        }
+
+        $options = array_merge($defaults, $options);
+
+        $instance = new self();
+        $instance->sharedOptions = $options['shared'];
+        $instance->formOptions = $options['form'];
+        $instance->viewOptions = $options['view'];
+        $instance->storageOptions = $options['storage'];
+
+        return $instance;
+    }
+
+    public function getSharedOptions()
+    {
+        return $this->sharedOptions;
+    }
+
+    public function getFormOptions()
+    {
+        return $this->formOptions;
+    }
+
+    public function getViewOptions()
+    {
+        return $this->viewOptions;
+    }
+
+    public function getStorageOptions()
+    {
+        return $this->storageOptions;
+    }
+}

--- a/src/Metadata/Annotations/Field.php
+++ b/src/Metadata/Annotations/Field.php
@@ -9,7 +9,10 @@ namespace Psi\Component\ContentType\Metadata\Annotations;
 class Field
 {
     public $type;
-    public $options = [];
+    public $shared = [];
+    public $form = [];
+    public $view = [];
+    public $storage = [];
     public $role;
     public $group;
 }

--- a/src/Metadata/Driver/AnnotationDriver.php
+++ b/src/Metadata/Driver/AnnotationDriver.php
@@ -39,7 +39,12 @@ class AnnotationDriver implements DriverInterface
                         $annotation->type,
                         $annotation->role,
                         $annotation->group,
-                        $annotation->options
+                        [
+                            'shared' => $annotation->shared,
+                            'form' => $annotation->form,
+                            'view' => $annotation->view,
+                            'storage' => $annotation->storage,
+                        ]
                     );
                     $propertyMetadatas[] = $propertyMetadata;
                 }

--- a/src/Metadata/Driver/ArrayDriver.php
+++ b/src/Metadata/Driver/ArrayDriver.php
@@ -39,7 +39,10 @@ class ArrayDriver implements AdvancedDriverInterface
             'type' => null,
             'role' => null,
             'group' => null,
-            'options' => [],
+            'shared' => [],
+            'form' => [],
+            'view' => [],
+            'storage' => [],
         ];
 
         foreach ($config['fields'] as $fieldName => $fieldConfig) {
@@ -57,7 +60,7 @@ class ArrayDriver implements AdvancedDriverInterface
                 $fieldConfig['type'],
                 $fieldConfig['role'],
                 $fieldConfig['group'],
-                $fieldConfig['options']
+                array_intersect_key($fieldConfig, array_flip(['view', 'storage', 'form', 'shared']))
             );
 
             $classMetadata->addPropertyMetadata($propertyMetadata);

--- a/src/Metadata/Driver/XmlDriver.php
+++ b/src/Metadata/Driver/XmlDriver.php
@@ -46,14 +46,23 @@ class XmlDriver extends AbstractFileDriver
             }
 
             foreach ($xpath->query('./psict:field', $classEl) as $fieldEl) {
-                $options = $this->extractOptions($xpath, $fieldEl);
+                $shared = $this->extractOptionSet($xpath, $fieldEl, 'shared-options');
+                $form = $this->extractOptionSet($xpath, $fieldEl, 'form-options');
+                $view = $this->extractOptionSet($xpath, $fieldEl, 'view-options');
+                $storage = $this->extractOptionSet($xpath, $fieldEl, 'storage-options');
+
                 $propertyMetadata = new PropertyMetadata(
                     $class->getName(),
                     $fieldEl->getAttribute('name'),
                     $fieldEl->getAttribute('type'),
                     $fieldEl->getAttribute('role'),
                     $fieldEl->getAttribute('group'),
-                    $options
+                    [
+                        'shared' => $shared,
+                        'form' => $form,
+                        'view' => $view,
+                        'storage' => $storage,
+                    ]
                 );
 
                 $classMetadata->addPropertyMetadata($propertyMetadata);
@@ -63,11 +72,18 @@ class XmlDriver extends AbstractFileDriver
         return $classMetadata;
     }
 
-    private function extractOptions(\DOMXPath $xpath, \DOMElement $fieldEl)
+    private function extractOptionSet(\DOMXpath $xpath, \DOMElement $fieldEl, $type)
+    {
+        foreach ($xpath->query('./psict:' . $type, $fieldEl) as $setEl) {
+            return $this->extractOptions($xpath, $setEl);
+        }
+    }
+
+    private function extractOptions(\DOMXPath $xpath, \DOMElement $setEl)
     {
         $options = [];
 
-        foreach ($xpath->query('./psict:option', $fieldEl) as $optionEl) {
+        foreach ($xpath->query('./psict:option', $setEl) as $optionEl) {
             if ($optionEl->getAttribute('type') === 'collection') {
                 $options[$optionEl->getAttribute('name')] = $this->extractOptions($xpath, $optionEl);
                 continue;

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -3,11 +3,12 @@
 namespace Psi\Component\ContentType\Metadata;
 
 use Metadata\PropertyMetadata as BasePropertyMetadata;
+use Psi\Component\ContentType\FieldOptions;
 
 class PropertyMetadata extends BasePropertyMetadata
 {
     private $type;
-    private $options = [];
+    private $options;
     private $role;
     private $group;
 
@@ -22,22 +23,22 @@ class PropertyMetadata extends BasePropertyMetadata
         parent::__construct($class, $name);
 
         $this->type = $type;
-        $this->options = $options;
         $this->role = $role;
         $this->group = $group;
+        $this->options = FieldOptions::create($options);
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    public function getOptions()
+    public function getOptions(): FieldOptions
     {
         return $this->options;
     }
@@ -47,7 +48,7 @@ class PropertyMetadata extends BasePropertyMetadata
         return $this->role;
     }
 
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }

--- a/src/OptionsResolver/FieldOptionsResolver.php
+++ b/src/OptionsResolver/FieldOptionsResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psi\Component\ContentType\OptionsResolver;
 
+use Psi\Component\ContentType\FieldOptions;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -43,29 +44,33 @@ class FieldOptionsResolver extends OptionsResolver
         $this->storageMapper = $optionMapper;
     }
 
-    public function resolveFormOptions(array $options = []): array
+    public function resolveFormOptions(FieldOptions $options): array
     {
-        return $this->resolveOptions($this->formMapper, $options);
+        return $this->resolveOptions($this->formMapper, $options->getSharedOptions(), $options->getFormOptions());
     }
 
-    public function resolveViewOptions(array $options = []): array
+    public function resolveViewOptions(FieldOptions $options): array
     {
-        return $this->resolveOptions($this->viewMapper, $options);
+        return $this->resolveOptions($this->viewMapper, $options->getSharedOptions(), $options->getViewOptions());
     }
 
-    public function resolveStorageOptions(array $options = []): array
+    public function resolveStorageOptions(FieldOptions $options): array
     {
-        return $this->resolveOptions($this->storageMapper, $options);
+        return $this->resolveOptions($this->storageMapper, $options->getSharedOptions(), $options->getViewOptions());
     }
 
-    private function resolveOptions($mapper, array $options): array
+    private function resolveOptions($mapper, array $sharedOptions, array $typeOptions): array
     {
+        // if no mapper was specified, then pass all of the type options
+        // directly.
         if (!$mapper) {
-            return [];
+            return $typeOptions;
         }
 
-        $options = $this->resolve($options);
+        // otherwise use the mapper callback, passing both type and shared
+        // options.
+        $options = $this->resolve($sharedOptions);
 
-        return $mapper($options);
+        return $mapper($typeOptions, $options);
     }
 }

--- a/src/Standard/Field/ChoiceField.php
+++ b/src/Standard/Field/ChoiceField.php
@@ -27,17 +27,5 @@ class ChoiceField implements FieldInterface
 
     public function configureOptions(FieldOptionsResolver $options)
     {
-        $options->setDefaults([
-            'choices' => [],
-            'expanded' => false,
-            'group_by' => null,
-            'multiple' => false,
-            'placeholder' => null,
-            'preferred_choices' => [],
-        ]);
-
-        $options->setFormMapper(function ($options) {
-            return $options;
-        });
     }
 }

--- a/src/Standard/Field/CollectionField.php
+++ b/src/Standard/Field/CollectionField.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psi\Component\ContentType\Standard\Field;
 
 use Psi\Component\ContentType\FieldInterface;
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\FieldRegistry;
 use Psi\Component\ContentType\OptionsResolver\FieldOptionsResolver;
 use Psi\Component\ContentType\Standard\Storage\CollectionType;
@@ -41,25 +42,33 @@ class CollectionField implements FieldInterface
             'field_type',
         ]);
         $options->setDefault('field_options', []);
-        $options->setFormMapper(function ($options) {
-            $field = $this->registry->get($options['field_type']);
-            $resolver = new FieldOptionsResolver();
-            $field->configureOptions($resolver);
-            $options = $resolver->resolveFormOptions($options['field_options']);
+        $options->setFormMapper(function (array $options, array $shared) {
 
-            return [
-                'entry_type' => $field->getFormType(),
-                'entry_options' => $options,
+            // default to allowing add / delete (contrary to the form types
+            // default behavior).
+            $options = array_merge([
                 'allow_add' => true,
                 'allow_delete' => true,
-            ];
+            ], $options);
+
+            // resolve the form options for the colletion entry.
+            $field = $this->registry->get($shared['field_type']);
+            $resolver = new FieldOptionsResolver();
+            $field->configureOptions($resolver);
+            $entryOptions = $resolver->resolveFormOptions(FieldOptions::create($shared['field_options']));
+
+            // do not allow entry_type or entry_options to be overridden.
+            $options['entry_type'] = $field->getFormType();
+            $options['entry_options'] = $entryOptions;
+
+            return $options;
         });
 
-        $options->setViewMapper(function ($options) {
-            return [
-                'field_type' => $options['field_type'],
-                'field_options' => $options['field_options'],
-            ];
+        $options->setViewMapper(function ($options, $shared) {
+            return array_merge($options, [
+                'field_type' => $shared['field_type'],
+                'field_options' => $shared['field_options'],
+            ]);
         });
     }
 }

--- a/src/Standard/Field/TextField.php
+++ b/src/Standard/Field/TextField.php
@@ -29,11 +29,5 @@ class TextField implements FieldInterface
 
     public function configureOptions(FieldOptionsResolver $options)
     {
-        $options->setDefault('tag', null);
-        $options->setViewMapper(function (array $options) {
-            return [
-                'tag' => $options['tag'],
-            ];
-        });
     }
 }

--- a/src/Standard/View/CollectionType.php
+++ b/src/Standard/View/CollectionType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psi\Component\ContentType\Standard\View;
 
 use Psi\Component\ContentType\FieldLoader;
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\View\TypeInterface;
 use Psi\Component\ContentType\View\ViewFactory;
 use Psi\Component\ContentType\View\ViewInterface;
@@ -34,7 +35,7 @@ class CollectionType implements TypeInterface
 
         $field = $this->fieldLoader->load(
             $options['field_type'],
-            $options['field_options']
+            FieldOptions::create($options['field_options'])
         );
 
         return new CollectionView(

--- a/tests/Functional/Example/Field/ImageField.php
+++ b/tests/Functional/Example/Field/ImageField.php
@@ -31,10 +31,10 @@ class ImageField implements FieldInterface
         $options->setDefault('repository', 'default');
         $options->setDefault('path', '/');
 
-        $options->setViewMapper(function (array $options) {
+        $options->setViewMapper(function (array $options, array $shared) {
             return [
-                'repository' => $options['repository'],
-                'path' => $options['path'],
+                'repository' => $shared['repository'],
+                'path' => $shared['path'],
             ];
         });
 

--- a/tests/Functional/Example/Field/ObjectReferenceField.php
+++ b/tests/Functional/Example/Field/ObjectReferenceField.php
@@ -28,9 +28,9 @@ class ObjectReferenceField implements FieldInterface
     public function configureOptions(FieldOptionsResolver $options)
     {
         $options->setDefault('class', null);
-        $options->setStorageMapper(function ($options) {
+        $options->setStorageMapper(function ($options, $shared) {
             return [
-                'class' => $options['class'],
+                'class' => $shared['class'],
             ];
         });
     }

--- a/tests/Functional/Form/Extension/FieldExtensionTest.php
+++ b/tests/Functional/Form/Extension/FieldExtensionTest.php
@@ -25,7 +25,7 @@ class FieldExtensionTest extends BaseTestCase
                         ],
                         'slideshow' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'image',
                             ],
                         ],

--- a/tests/Functional/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Functional/Metadata/Driver/AnnotationDriverTest.php
@@ -27,7 +27,10 @@ class AnnotationDriverTest extends BaseTestCase
         $this->assertEquals('foobar', $properties['title']->getGroup());
         $this->assertEquals('markdown', $properties['body']->getType());
         $this->assertEquals('image-collection', $properties['slider']->getType());
-        $this->assertEquals(['max' => 10], $properties['slider']->getOptions());
+        $this->assertEquals(['max' => 10], $properties['slider']->getOptions()->getSharedOptions());
+        $this->assertEquals(['foo' => 'bar'], $properties['slider']->getOptions()->getFormOptions());
+        $this->assertEquals(['tag' => 'h1'], $properties['slider']->getOptions()->getViewOptions());
+        $this->assertEquals(['serialize' => false], $properties['slider']->getOptions()->getStorageOptions());
     }
 
     /**

--- a/tests/Functional/Metadata/Driver/Model/Article.php
+++ b/tests/Functional/Metadata/Driver/Model/Article.php
@@ -17,7 +17,7 @@ class Article
     public $body;
 
     /**
-     * @CMFCT\Field(type="image-collection", options={ "max" = 10 })
+     * @CMFCT\Field(type="image-collection", shared={ "max" = 10 }, form={ "foo": "bar" }, view={"tag": "h1"}, storage={"serialize": false})
      */
     public $slider;
 }

--- a/tests/Functional/View/ViewTest.php
+++ b/tests/Functional/View/ViewTest.php
@@ -27,7 +27,7 @@ class ViewTest extends BaseTestCase
                         ],
                         'slideshow' => [
                             'type' => 'collection',
-                            'options' => [
+                            'shared' => [
                                 'field_type' => 'image',
                                 'field_options' => [],
                             ],

--- a/tests/Unit/FieldLoaderTest.php
+++ b/tests/Unit/FieldLoaderTest.php
@@ -5,6 +5,7 @@ namespace Psi\Component\ContentType\Tests\Unit;
 use Psi\Component\ContentType\Field;
 use Psi\Component\ContentType\FieldInterface;
 use Psi\Component\ContentType\FieldLoader;
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\FieldRegistry;
 use Psi\Component\ContentType\Metadata\PropertyMetadata;
 
@@ -31,7 +32,7 @@ class FieldLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $this->fieldRegistry->get('foobar')->willReturn($this->field1);
 
-        $field = $this->loader->load('foobar', []);
+        $field = $this->loader->load('foobar', FieldOptions::create([]));
 
         $this->assertInstanceOf(Field::class, $field);
     }
@@ -44,10 +45,10 @@ class FieldLoaderTest extends \PHPUnit_Framework_TestCase
         $this->fieldRegistry->get('foobar')->shouldBeCalledTimes(2)->willReturn($this->field1);
         $this->fieldRegistry->get('barfoo')->shouldBeCalledTimes(1)->willReturn($this->field1);
 
-        $field1 = $this->loader->load('foobar', []);
-        $field2 = $this->loader->load('barfoo', []);
-        $field3 = $this->loader->load('foobar', []);
-        $field4 = $this->loader->load('foobar', ['fo' => 'ba']);
+        $field1 = $this->loader->load('foobar', FieldOptions::create([]));
+        $field2 = $this->loader->load('barfoo', FieldOptions::create([]));
+        $field3 = $this->loader->load('foobar', FieldOptions::create([]));
+        $field4 = $this->loader->load('foobar', FieldOptions::create(['shared' => ['fo' => 'ba']]));
 
         $this->assertSame($field1, $field3);
         $this->assertNotSame($field2, $field1);

--- a/tests/Unit/FieldTest.php
+++ b/tests/Unit/FieldTest.php
@@ -5,6 +5,7 @@ namespace Psi\Component\ContentType\Tests\Unit;
 use Prophecy\Argument;
 use Psi\Component\ContentType\Field;
 use Psi\Component\ContentType\FieldInterface;
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\OptionsResolver\FieldOptionsResolver;
 
 class FieldTest extends \PHPUnit_Framework_TestCase
@@ -28,8 +29,10 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         $mapperMethod = sprintf('set%sMapper', $type);
 
         $field = $this->createField([
-            'foo' => 'bar',
-            'bar' => 'foo',
+            'shared' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+            ],
         ]);
 
         $this->innerField->configureOptions(Argument::type(FieldOptionsResolver::class))->will(function ($args) use ($mapperMethod) {
@@ -37,9 +40,9 @@ class FieldTest extends \PHPUnit_Framework_TestCase
                 'foo' => '0',
                 'bar' => '2',
             ]);
-            $args[0]->$mapperMethod(function ($options) {
+            $args[0]->$mapperMethod(function ($options, $shared) {
                 return [
-                    'foo' => $options['foo'],
+                    'foo' => $shared['foo'],
                     'car' => 'zar',
                 ];
             });
@@ -64,8 +67,10 @@ class FieldTest extends \PHPUnit_Framework_TestCase
     {
         $optionsMethod = sprintf('get%sOptions', $type);
         $field = $this->createField([
-            'foo' => 'bar',
-            'bar' => 'foo',
+            'shared' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+            ],
         ]);
 
         $this->innerField->configureOptions(Argument::type(FieldOptionsResolver::class))->shouldBeCalled();
@@ -109,6 +114,6 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 
     private function createField(array $options)
     {
-        return new Field($this->innerField->reveal(), $options);
+        return new Field($this->innerField->reveal(), FieldOptions::create($options));
     }
 }

--- a/tests/Unit/Form/Extension/Type/SurrogateTypeTest.php
+++ b/tests/Unit/Form/Extension/Type/SurrogateTypeTest.php
@@ -4,6 +4,7 @@ namespace Psi\Component\ContentType\Tests\Unit\Form\Extension\Type;
 
 use Prophecy\Argument;
 use Psi\Component\ContentType\FieldInterface;
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\FieldRegistry;
 use Psi\Component\ContentType\Form\Extension\Type\SurrogateType;
 use Psi\Component\ContentType\Metadata\ClassMetadata;
@@ -46,7 +47,7 @@ class SurrogateTypeTest extends TypeTestCase
         $propertyName = 'propname';
         $formType = TextType::class;
 
-        $property = $this->createProperty($propertyName, $type, null, ['data' => 'value']);
+        $property = $this->createProperty($propertyName, $type, null, ['shared' => ['data' => 'value']]);
         $this->classMetadata->getPropertyMetadata()->willReturn([
             $property,
         ]);
@@ -72,9 +73,9 @@ class SurrogateTypeTest extends TypeTestCase
         $type = 'hello';
         $formType = TextType::class;
 
-        $property1 = $this->createProperty('ungrouped_prop', $type, null, ['data' => 'value']);
-        $property2 = $this->createProperty('grouped_1', $type, 'hello', ['data' => 'value']);
-        $property3 = $this->createProperty('grouped_2', $type, 'hello', ['data' => 'value']);
+        $property1 = $this->createProperty('ungrouped_prop', $type, null, ['shared' => ['data' => 'value']]);
+        $property2 = $this->createProperty('grouped_1', $type, 'hello', ['shared' => ['data' => 'value']]);
+        $property3 = $this->createProperty('grouped_2', $type, 'hello', ['shared' => ['data' => 'value']]);
         $this->classMetadata->getPropertyMetadata()->willReturn([
             $property1,
             $property2,
@@ -111,7 +112,7 @@ class SurrogateTypeTest extends TypeTestCase
         $property = $this->prophesize(PropertyMetadata::class);
         $property->getType()->willReturn($type);
         $property->getGroup()->willReturn($group);
-        $property->getOptions()->willReturn($options);
+        $property->getOptions()->willReturn(FieldOptions::create($options));
         $property->getName()->willReturn($propertyName);
 
         return $property;

--- a/tests/Unit/Metadata/Driver/ArrayDriverTest.php
+++ b/tests/Unit/Metadata/Driver/ArrayDriverTest.php
@@ -31,7 +31,7 @@ class ArrayDriverTest extends \PHPUnit_Framework_TestCase
                     'title' => [
                         'type' => 'Class\Fqn\TextField',
                         'group' => 'foobar',
-                        'options' => [
+                        'shared' => [
                             'option_1' => 100,
                         ],
                     ],
@@ -51,7 +51,7 @@ class ArrayDriverTest extends \PHPUnit_Framework_TestCase
 
         $property1 = current($properties);
         $this->assertEquals('Class\Fqn\TextField', $property1->getType());
-        $this->assertEquals(['option_1' => 100], $property1->getOptions());
+        $this->assertEquals(['option_1' => 100], $property1->getOptions()->getSharedOptions());
         $this->assertEquals('foobar', $property1->getGroup());
 
         $property2 = next($properties);
@@ -72,7 +72,7 @@ class ArrayDriverTest extends \PHPUnit_Framework_TestCase
      * It should throw an exception if invalid field configuration keys are given.
      *
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid configuration key(s) "bar", "foo" for field "title" on class "Psi\Component\ContentType\Tests\Unit\Metadata\Driver\TestContent", valid keys: "type", "role", "group", "options"
+     * @expectedExceptionMessage Invalid configuration key(s) "bar", "foo" for field "title" on class "Psi\Component\ContentType\Tests\Unit\Metadata\Driver\TestContent", valid keys: "type", "role", "group", "shared", "form", "view", "storage"
      */
     public function testInvalidKeys()
     {
@@ -84,7 +84,7 @@ class ArrayDriverTest extends \PHPUnit_Framework_TestCase
                         'bar' => 'boo',
                         'foo' => 'baa',
                         'type' => 'Class\Fqn\TextField',
-                        'options' => [
+                        'shared' => [
                             'option_1' => 100,
                         ],
                     ],

--- a/tests/Unit/Metadata/Driver/XmlDriverTest.php
+++ b/tests/Unit/Metadata/Driver/XmlDriverTest.php
@@ -29,6 +29,7 @@ class XmlDriverTest extends \PHPUnit_Framework_TestCase
         $properties = $metadata->getPropertyMetadata();
         $this->assertArrayHasKey('fieldOne', $properties);
         $propertyOne = $properties['fieldOne'];
+
         $this->assertEquals('markdown', $propertyOne->getType());
         $this->assertEquals('title', $propertyOne->getRole());
         $this->assertEquals('group_one', $propertyOne->getGroup());
@@ -39,7 +40,21 @@ class XmlDriverTest extends \PHPUnit_Framework_TestCase
                 'sub_one' => 'One',
                 'sub_two' => 'Two',
             ],
-        ], $propertyOne->getOptions());
+        ], $propertyOne->getOptions()->getSharedOptions());
+
+        $this->assertEquals([
+            'a' => 'A',
+            'b' => 'B',
+        ], $propertyOne->getOptions()->getFormOptions());
+
+        $this->assertEquals([
+            'c' => 'C',
+        ], $propertyOne->getOptions()->getViewOptions());
+
+        $this->assertEquals([
+            'd' => 'D',
+        ], $propertyOne->getOptions()->getStorageOptions());
+
         $this->assertArrayHasKey('fieldTwo', $properties);
     }
 

--- a/tests/Unit/Metadata/Driver/xml/Example.xml
+++ b/tests/Unit/Metadata/Driver/xml/Example.xml
@@ -11,17 +11,36 @@
         >
 
         <field name="fieldOne" type="markdown" role="title" group="group_one">
-            <option name="option_one">Foobar</option>
-            <option name="option_two">Barfoo</option>
-            <option name="option_three" type="collection">
-                <option name="sub_one">One</option>
-                <option name="sub_two">Two</option>
-            </option>
+
+            <shared-options>
+                <option name="option_one">Foobar</option>
+                <option name="option_two">Barfoo</option>
+                <option name="option_three" type="collection">
+                    <option name="sub_one">One</option>
+                    <option name="sub_two">Two</option>
+                </option>
+            </shared-options>
+
+            <form-options>
+                <option name="a">A</option>
+                <option name="b">B</option>
+            </form-options>
+
+            <view-options>
+                <option name="c">C</option>
+            </view-options>
+
+            <storage-options>
+                <option name="d">D</option>
+            </storage-options>
+
         </field>
 
         <field name="fieldTwo" type="date">
-            <option name="option_one">Foobar</option>
-            <option name="option_two">Barfoo</option>
+            <shared-options>
+                <option name="option_one">Foobar</option>
+                <option name="option_two">Barfoo</option>
+            </shared-options>
         </field>
 
     </class>

--- a/tests/Unit/OptionsResolver/FieldOptionsResolverTest.php
+++ b/tests/Unit/OptionsResolver/FieldOptionsResolverTest.php
@@ -2,6 +2,7 @@
 
 namespace Psi\Component\ContentType\Tests\Unit\OptionsResolver;
 
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\OptionsResolver\FieldOptionsResolver;
 
 class FieldOptionsResolverTest extends \PHPUnit_Framework_TestCase
@@ -29,7 +30,22 @@ class FieldOptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->setDefault('foo', 'bar');
         $this->resolver->setDefault('bar', 'foo');
 
-        $this->assertEquals([], $this->resolver->resolveFormOptions());
+        $this->assertEquals([], $this->resolver->resolveFormOptions(FieldOptions::create([])));
+    }
+
+    /**
+     * It should pass type options directly if no mapper is provided.
+     */
+    public function testNoFormMapperPassDirect()
+    {
+        $this->resolver->setDefault('foo', 'bar');
+        $this->resolver->setDefault('bar', 'foo');
+
+        $this->assertEquals(['foo' => 'bar'], $this->resolver->resolveFormOptions(FieldOptions::create([
+            'form' => [
+                'foo' => 'bar',
+            ],
+        ])));
     }
 
     /**
@@ -48,7 +64,7 @@ class FieldOptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->setDefault('foo', 'bar');
         $this->resolver->setDefault('bar', 'foo');
 
-        $this->assertEquals([], $this->resolver->resolveViewOptions());
+        $this->assertEquals([], $this->resolver->resolveViewOptions(FieldOptions::create([])));
     }
 
     private function doTestMapOptions($type)
@@ -58,9 +74,9 @@ class FieldOptionsResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->resolver->setDefault('foo', 'bar');
         $this->resolver->setDefault('bar', 'foo');
-        $this->resolver->$setMethod(function (array $options) {
+        $this->resolver->$setMethod(function (array $options, array $shared) {
             return [
-                'baz' => $options['bar'],
+                'baz' => $shared['bar'],
                 'ban' => 'bon',
             ];
         });
@@ -74,6 +90,6 @@ class FieldOptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'baz' => 'foo',
             'ban' => 'bon',
-        ], $this->resolver->$resolveMethod());
+        ], $this->resolver->$resolveMethod(FieldOptions::create([])));
     }
 }

--- a/tests/Unit/Standard/View/CollectionTypeTest.php
+++ b/tests/Unit/Standard/View/CollectionTypeTest.php
@@ -4,6 +4,7 @@ namespace Psi\Component\ContentType\Tests\Unit\Standard\View;
 
 use Psi\Component\ContentType\Field;
 use Psi\Component\ContentType\FieldLoader;
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\Standard\View\CollectionType;
 use Psi\Component\ContentType\Standard\View\CollectionView;
 use Psi\Component\ContentType\View\View;
@@ -35,11 +36,14 @@ class CollectionTypeTest extends TypeTestCase
     {
         $fieldType = 'foo';
         $viewType = 'view_type';
-        $fieldOptions = $viewOptions = ['foo' => 'bar'];
+        $viewOptions = ['foo' => 'bar'];
+        $fieldOptions = [
+            'view' => $viewOptions,
+        ];
 
         $this->fieldLoader->load(
             $fieldType,
-            $fieldOptions
+            FieldOptions::create($fieldOptions)
         )->willReturn($this->field->reveal());
         $this->field->getViewType()->willReturn($viewType);
         $this->field->getViewOptions()->willReturn($viewOptions);

--- a/tests/Unit/Standard/View/ObjectTypeTest.php
+++ b/tests/Unit/Standard/View/ObjectTypeTest.php
@@ -7,6 +7,7 @@ use Metadata\NullMetadata;
 use Psi\Component\ContentType\Field;
 use Psi\Component\ContentType\FieldInterface;
 use Psi\Component\ContentType\FieldLoader;
+use Psi\Component\ContentType\FieldOptions;
 use Psi\Component\ContentType\Metadata\ClassMetadata;
 use Psi\Component\ContentType\Metadata\PropertyMetadata;
 use Psi\Component\ContentType\Standard\View\ObjectType;
@@ -71,19 +72,22 @@ class ObjectTypeTest extends TypeTestCase
             $this->propertyMetadata1->reveal(),
         ]);
 
-        $options = ['foo' => 'bar'];
+        $viewOptions = ['foo' => 'bar'];
+        $options = FieldOptions::create([
+            'view' => $viewOptions,
+        ]);
         $this->propertyMetadata1->getType()->willReturn('foobar');
         $this->propertyMetadata1->getName()->willReturn('prop1');
         $this->propertyMetadata1->getOptions()->willReturn($options);
         $this->propertyMetadata1->getValue($content)->willReturn($value);
 
-        $this->viewFactory->create('foobar', $value, $options)->willReturn($this->childView->reveal());
+        $this->viewFactory->create('foobar', $value, $viewOptions)->willReturn($this->childView->reveal());
 
         $this->fieldLoader->load('foobar', $options)->willReturn(
             $this->field->reveal()
         );
         $this->field->getViewType()->willReturn('foobar');
-        $this->field->getViewOptions()->willReturn($options);
+        $this->field->getViewOptions()->willReturn($viewOptions);
 
         $view = $this->getType()->createView(
             $this->viewFactory->reveal(),


### PR DESCRIPTION
- Segregate options
- Allow options to be passed directly to "types"
- Allow mappers to override what can be passed directly to "types"
- Allow mappers to access shared options (as may defined by the field itself).

Fixes #52 